### PR TITLE
Feature aliases w plugin

### DIFF
--- a/app/actions/remote/aliases.ts
+++ b/app/actions/remote/aliases.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {General} from '@constants';
+import DatabaseManager from '@database/manager';
+import NetworkManager from '@managers/network_manager';
+import {getAliasesCollection} from '@queries/servers/aliases';
+import {getFullErrorMessage} from '@utils/errors';
+import {logDebug} from '@utils/log';
+
+import type {Collection, Database} from '@nozbe/watermelondb';
+import type AliasesModel from '@typings/database/models/servers/aliases';
+
+const deleteExistingAliases = async (
+    database: Database,
+    dbAliases: Collection<AliasesModel>,
+) => {
+    const allAliases = await dbAliases.query().fetch();
+    await database.batch(
+        ...allAliases.map((alias) => alias.prepareDestroyPermanently()),
+    );
+};
+
+const createNewAliases = async (
+    dbAliases: Collection<AliasesModel>,
+    aliases: Record<string, string>,
+) => {
+    await Promise.all(
+        Object.entries(aliases).map(([from, to]) =>
+            dbAliases.create((record) => {
+                record.from = from;
+                record.to = to;
+            }),
+        ),
+    );
+};
+
+export const fetchAliases = async (serverUrl: string) => {
+    try {
+        const {database} =
+            DatabaseManager.getServerDatabaseAndOperator(serverUrl);
+        const dbAliases = await getAliasesCollection(database);
+        const client = NetworkManager.getClient(serverUrl);
+        const manifests = await client.getPluginsManifests();
+
+        if (!manifests.map((v) => v.id).includes(General.ALIASES_PLUGIN_ID)) {
+            return {};
+        }
+
+        const aliases = await client.getAliases();
+        if (!dbAliases) {
+            return aliases;
+        }
+
+        await database.write(async () => {
+            await deleteExistingAliases(database, dbAliases);
+            await createNewAliases(dbAliases, aliases);
+        });
+
+        return aliases;
+    } catch (error) {
+        logDebug('error on getting aliases', getFullErrorMessage(error));
+        return {};
+    }
+};

--- a/app/actions/websocket/event.ts
+++ b/app/actions/websocket/event.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import * as bookmark from '@actions/local/channel_bookmark';
+import {fetchAliases} from '@actions/remote/aliases';
 import * as calls from '@calls/connection/websocket_event_handlers';
 import {WebsocketEvents} from '@constants';
 
@@ -293,6 +294,9 @@ export async function handleWebSocketEvent(serverUrl: string, msg: WebSocketMess
             break;
         case WebsocketEvents.CHANNEL_BOOKMARK_SORTED:
             bookmark.handleBookmarkSorted(serverUrl, msg);
+            break;
+        case WebsocketEvents.ALIAS_UPDATE:
+            fetchAliases(serverUrl);
             break;
     }
 }

--- a/app/client/rest/aliases.ts
+++ b/app/client/rest/aliases.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {General} from '@constants';
+
+import type ClientBase from './base';
+
+export interface ClientAliasesMix {
+    getAliases: () => Promise<Record<string, string>>;
+}
+
+const ClientAliases = <TBase extends Constructor<ClientBase>>(superclass: TBase) => class extends superclass {
+    getAliases = async () => {
+        return this.doFetch(
+            `${this.getPluginRoute(General.ALIASES_PLUGIN_ID)}/api/v1/aliases`,
+            {method: 'get'},
+        );
+    };
+};
+
+export default ClientAliases;

--- a/app/client/rest/index.ts
+++ b/app/client/rest/index.ts
@@ -5,6 +5,7 @@ import ClientCalls, {type ClientCallsMix} from '@calls/client/rest';
 import ClientPlugins, {type ClientPluginsMix} from '@client/rest/plugins';
 import mix from '@utils/mix';
 
+import ClientAliases, {type ClientAliasesMix} from './aliases';
 import ClientApps, {type ClientAppsMix} from './apps';
 import ClientBase from './base';
 import ClientCategories, {type ClientCategoriesMix} from './categories';
@@ -46,7 +47,8 @@ interface Client extends ClientBase,
     ClientCallsMix,
     ClientPluginsMix,
     ClientNPSMix,
-    ClientCustomAttributesMix
+    ClientCustomAttributesMix,
+    ClientAliasesMix
 {}
 
 class Client extends mix(ClientBase).with(
@@ -69,6 +71,7 @@ class Client extends mix(ClientBase).with(
     ClientPlugins,
     ClientNPS,
     ClientCustomAttributes,
+    ClientAliases,
 ) {
     // eslint-disable-next-line no-useless-constructor
     constructor(apiClient: APIClientInterface, serverUrl: string, bearerToken?: string, csrfToken?: string) {

--- a/app/components/channel_item/channel_item.tsx
+++ b/app/components/channel_item/channel_item.tsx
@@ -3,7 +3,7 @@
 
 import React, {useCallback, useMemo} from 'react';
 import {useIntl} from 'react-intl';
-import {StyleSheet, TouchableOpacity, View} from 'react-native';
+import {StyleSheet, TouchableOpacity, View, Text} from 'react-native';
 
 import Badge from '@components/badge';
 import ChannelIcon from '@components/channel_icon';
@@ -37,6 +37,7 @@ type Props = {
     isOnCenterBg?: boolean;
     showChannelName?: boolean;
     isOnHome?: boolean;
+    alias?: string;
 }
 
 export const ROW_HEIGHT = 40;
@@ -97,6 +98,9 @@ export const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
     filler: {
         flex: 1,
     },
+    alias: {
+        color: changeOpacity(theme.sidebarText, 0.5),
+    },
 }));
 
 export const textStyle = StyleSheet.create({
@@ -120,6 +124,7 @@ const ChannelItem = ({
     isOnCenterBg = false,
     showChannelName = false,
     isOnHome = false,
+    alias,
 }: Props) => {
     const {formatMessage} = useIntl();
     const theme = useTheme();
@@ -200,6 +205,7 @@ const ChannelItem = ({
                     textStyles={textStyles}
                     channelName={channelName}
                 />
+                {alias && <Text style={styles.alias}> {`(${alias})`}</Text>}
                 <View style={styles.filler}/>
                 <Badge
                     visible={mentionsCount > 0}

--- a/app/constants/database.ts
+++ b/app/constants/database.ts
@@ -10,6 +10,7 @@ export const MM_TABLES = {
         SERVERS: 'Servers',
     },
     SERVER: {
+        ALIASES: 'Aliases',
         CATEGORY: 'Category',
         CATEGORY_CHANNEL: 'CategoryChannel',
         CHANNEL: 'Channel',

--- a/app/constants/general.ts
+++ b/app/constants/general.ts
@@ -42,6 +42,7 @@ export default {
     RESTRICT_DIRECT_MESSAGE_ANY: 'any',
     TIME_TO_FIRST_REVIEW: toMilliseconds({days: 14}),
     TIME_TO_NEXT_REVIEW: toMilliseconds({days: 90}),
+    ALIASES_PLUGIN_ID: 'com.mattermost.plugin-name-aliases',
     NPS_PLUGIN_ID: 'com.mattermost.nps',
     NPS_PLUGIN_BOT_USERNAME: 'feedbackbot',
 };

--- a/app/constants/websocket.ts
+++ b/app/constants/websocket.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {General} from '@constants';
 import Calls from '@constants/calls';
 
 const WebsocketEvents = {
@@ -104,5 +105,7 @@ const WebsocketEvents = {
     CHANNEL_BOOKMARK_UPDATED: 'channel_bookmark_updated',
     CHANNEL_BOOKMARK_SORTED: 'channel_bookmark_sorted',
     CHANNEL_BOOKMARK_DELETED: 'channel_bookmark_deleted',
+
+    ALIAS_UPDATE: `custom_${General.ALIASES_PLUGIN_ID}_alias_update`,
 };
 export default WebsocketEvents;

--- a/app/database/manager/index.ts
+++ b/app/database/manager/index.ts
@@ -16,7 +16,7 @@ import {CategoryModel, CategoryChannelModel, ChannelModel, ChannelBookmarkModel,
     GroupModel, GroupChannelModel, GroupTeamModel, GroupMembershipModel, MyChannelModel, MyChannelSettingsModel, MyTeamModel,
     PostModel, PostsInChannelModel, PostsInThreadModel, PreferenceModel, ReactionModel, RoleModel,
     SystemModel, TeamModel, TeamChannelHistoryModel, TeamMembershipModel, TeamSearchHistoryModel,
-    ThreadModel, ThreadParticipantModel, ThreadInTeamModel, TeamThreadsSyncModel, UserModel, ConfigModel,
+    ThreadModel, ThreadParticipantModel, ThreadInTeamModel, TeamThreadsSyncModel, UserModel, ConfigModel, AliasesModel,
 } from '@database/models/server';
 import AppDataOperator from '@database/operator/app_data_operator';
 import ServerDataOperator from '@database/operator/server_data_operator';
@@ -48,7 +48,7 @@ class DatabaseManagerSingleton {
             GroupModel, GroupChannelModel, GroupTeamModel, GroupMembershipModel, MyChannelModel, MyChannelSettingsModel, MyTeamModel,
             PostModel, PostsInChannelModel, PostsInThreadModel, PreferenceModel, ReactionModel, RoleModel,
             SystemModel, TeamModel, TeamChannelHistoryModel, TeamMembershipModel, TeamSearchHistoryModel,
-            ThreadModel, ThreadParticipantModel, ThreadInTeamModel, TeamThreadsSyncModel, UserModel,
+            ThreadModel, ThreadParticipantModel, ThreadInTeamModel, TeamThreadsSyncModel, UserModel, AliasesModel,
         ];
 
         this.databaseDirectory = Platform.OS === 'ios' ? getIOSAppGroupDetails().appGroupDatabase : `${documentDirectory}/databases/`;

--- a/app/database/migration/server/index.ts
+++ b/app/database/migration/server/index.ts
@@ -12,6 +12,18 @@ const {CHANNEL_BOOKMARK, CHANNEL_INFO, DRAFT, POST} = MM_TABLES.SERVER;
 
 export default schemaMigrations({migrations: [
     {
+        toVersion: 7,
+        steps: [
+            createTable({
+                name: 'Aliases',
+                columns: [
+                    {name: 'from', type: 'string'},
+                    {name: 'to', type: 'string'},
+                ],
+            }),
+        ],
+    },
+    {
         toVersion: 6,
         steps: [
             unsafeExecuteSql('CREATE INDEX IF NOT EXISTS Post_type ON Post (type);'),

--- a/app/database/models/server/aliases.ts
+++ b/app/database/models/server/aliases.ts
@@ -1,0 +1,23 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Model} from '@nozbe/watermelondb';
+import {field} from '@nozbe/watermelondb/decorators';
+
+import {MM_TABLES} from '@constants/database';
+
+import type AliasesModelInterface from '@typings/database/models/servers/aliases';
+
+const {ALIASES} = MM_TABLES.SERVER;
+
+/**
+ * The Config model is another set of key-value pair combination but this one
+ * will hold the server configuration.
+ */
+export default class AliasesModel extends Model implements AliasesModelInterface {
+    /** table (name) : Config */
+    static table = ALIASES;
+
+    @field('from') from!: string;
+    @field('to') to!: string;
+}

--- a/app/database/models/server/index.ts
+++ b/app/database/models/server/index.ts
@@ -34,3 +34,4 @@ export {default as ThreadInTeamModel} from './thread_in_team';
 export {default as ThreadParticipantModel} from './thread_participant';
 export {default as TeamThreadsSyncModel} from './team_threads_sync';
 export {default as UserModel} from './user';
+export {default as AliasesModel} from './aliases';

--- a/app/database/schema/server/index.ts
+++ b/app/database/schema/server/index.ts
@@ -37,10 +37,11 @@ import {
     ThreadParticipantSchema,
     TeamThreadsSyncSchema,
     UserSchema,
+    AliasesSchema,
 } from './table_schemas';
 
 export const serverSchema: AppSchema = appSchema({
-    version: 6,
+    version: 7,
     tables: [
         CategorySchema,
         CategoryChannelSchema,
@@ -75,5 +76,6 @@ export const serverSchema: AppSchema = appSchema({
         ThreadInTeamSchema,
         ThreadParticipantSchema,
         UserSchema,
+        AliasesSchema,
     ],
 });

--- a/app/database/schema/server/table_schemas/aliases.ts
+++ b/app/database/schema/server/table_schemas/aliases.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {tableSchema} from '@nozbe/watermelondb';
+
+import {MM_TABLES} from '@constants/database';
+
+const {ALIASES} = MM_TABLES.SERVER;
+
+export default tableSchema({
+    name: ALIASES,
+    columns: [
+        {name: 'from', type: 'string'},
+        {name: 'to', type: 'string'},
+    ],
+});

--- a/app/database/schema/server/table_schemas/index.ts
+++ b/app/database/schema/server/table_schemas/index.ts
@@ -34,3 +34,4 @@ export {default as ThreadInTeamSchema} from './thread_in_team';
 export {default as TeamThreadsSyncSchema} from './team_threads_sync';
 export {default as UserSchema} from './user';
 export {default as ConfigSchema} from './config';
+export {default as AliasesSchema} from './aliases';

--- a/app/queries/servers/aliases.ts
+++ b/app/queries/servers/aliases.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {MM_TABLES} from '@constants/database';
+
+import type {Database} from '@nozbe/watermelondb';
+import type AliasesModel from '@typings/database/models/servers/aliases';
+
+const {
+    SERVER: {ALIASES},
+} = MM_TABLES;
+
+export const getAliasesCollection = (database: Database) => {
+    try {
+        const aliasesModel = database.collections.get<AliasesModel>(ALIASES);
+
+        return aliasesModel;
+    } catch {
+        return undefined;
+    }
+};
+
+export const getAliases = async (database: Database) => {
+    try {
+        const aliasesCollection = getAliasesCollection(database);
+        if (aliasesCollection) {
+            const aliases = await aliasesCollection.query().fetch();
+            return aliases;
+        }
+        return undefined;
+    } catch (error) {
+        return undefined;
+    }
+};

--- a/app/queries/servers/aliases.ts
+++ b/app/queries/servers/aliases.ts
@@ -1,9 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {Q, type Database} from '@nozbe/watermelondb';
+import {switchMap} from '@nozbe/watermelondb/utils/rx';
+import {of as of$} from 'rxjs';
+
 import {MM_TABLES} from '@constants/database';
 
-import type {Database} from '@nozbe/watermelondb';
 import type AliasesModel from '@typings/database/models/servers/aliases';
 
 const {
@@ -31,4 +34,29 @@ export const getAliases = async (database: Database) => {
     } catch (error) {
         return undefined;
     }
+};
+
+export const getAliasById = async (database: Database, id: string) => {
+    try {
+        const aliases = await getAliases(database);
+        if (aliases) {
+            const foundAlias = aliases.find(({from}) => from === id);
+            return foundAlias?.to;
+        }
+
+        return undefined;
+    } catch (error) {
+        return undefined;
+    }
+};
+
+export const observeAliasStringByChannelId = (database: Database, channelId: string) => {
+    const collection = getAliasesCollection(database);
+    if (!collection) {
+        return of$(undefined);
+    }
+
+    return collection.query(Q.where('from', channelId)).observe().pipe(
+        switchMap((aliases) => of$(aliases.length ? aliases[0].to : undefined)),
+    );
 };

--- a/app/screens/channel/header/header.tsx
+++ b/app/screens/channel/header/header.tsx
@@ -51,6 +51,7 @@ type ChannelProps = {
     groupCallsAllowed: boolean;
     isTabletView?: boolean;
     shouldRenderBookmarks: boolean;
+    alias?: string;
 };
 
 const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
@@ -82,6 +83,7 @@ const ChannelHeader = ({
     canAddBookmarks, channelId, channelType, componentId, customStatus, displayName, hasBookmarks,
     isBookmarksEnabled, isCustomStatusEnabled, isCustomStatusExpired, isOwnDirectMessage, memberCount,
     searchTerm, teamId, callsEnabledInChannel, groupCallsAllowed, isTabletView, shouldRenderBookmarks,
+    alias,
 }: ChannelProps) => {
     const intl = useIntl();
     const isTablet = useIsTablet();
@@ -199,6 +201,10 @@ const ChannelHeader = ({
     let title = displayName;
     if (isOwnDirectMessage) {
         title = intl.formatMessage({id: 'channel_header.directchannel.you', defaultMessage: '{displayName} (you)'}, {displayName});
+    }
+
+    if (alias) {
+        title = `${title} (${alias})`;
     }
 
     let subtitle;

--- a/app/screens/channel/header/index.ts
+++ b/app/screens/channel/header/index.ts
@@ -7,6 +7,7 @@ import {of as of$} from 'rxjs';
 import {combineLatestWith, distinctUntilChanged, switchMap} from 'rxjs/operators';
 
 import {General} from '@constants';
+import {observeAliasStringByChannelId} from '@queries/servers/aliases';
 import {observeChannel, observeChannelInfo} from '@queries/servers/channel';
 import {observeCanAddBookmarks, queryBookmarks} from '@queries/servers/channel_bookmark';
 import {observeConfigBooleanValue, observeCurrentTeamId, observeCurrentUserId} from '@queries/servers/system';
@@ -86,6 +87,16 @@ const enhanced = withObservables(['channelId'], ({channelId, database}: OwnProps
     const isBookmarksEnabled = observeConfigBooleanValue(database, 'FeatureFlagChannelBookmarks');
     const canAddBookmarks = observeCanAddBookmarks(database, channelId);
 
+    const alias = dmUser.pipe(
+        switchMap((user) => {
+            if (user) {
+                return observeAliasStringByChannelId(database, user.id);
+            }
+            return of$(undefined);
+        }),
+        distinctUntilChanged(),
+    );
+
     return {
         canAddBookmarks,
         channelType,
@@ -99,6 +110,7 @@ const enhanced = withObservables(['channelId'], ({channelId, database}: OwnProps
         memberCount,
         searchTerm,
         teamId,
+        alias,
     };
 });
 

--- a/types/database/models/servers/aliases.ts
+++ b/types/database/models/servers/aliases.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {Model} from '@nozbe/watermelondb';
+
+/**
+ * The Config model is another set of key-value pair combination but this one
+ * will hold the server configuration.
+ */
+declare class AliasesModel extends Model {
+    /** table (name) : Config */
+    static table: string;
+
+    /** value : The value for that config/information and whose key will be the id column  */
+    from: string;
+    to: string;
+}
+
+export default AliasesModel;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
