### PR TITLE
feature: add alias button

### DIFF
--- a/app/constants/screens.ts
+++ b/app/constants/screens.ts
@@ -3,6 +3,7 @@
 
 export const ABOUT = 'About';
 export const ACCOUNT = 'Account';
+export const ALIAS_MODAL = 'AliasModal';
 export const APPS_FORM = 'AppForm';
 export const BOTTOM_SHEET = 'BottomSheet';
 export const BROWSE_CHANNELS = 'BrowseChannels';
@@ -85,6 +86,7 @@ export const GENERIC_OVERLAY = 'GenericOverlay';
 export default {
     ABOUT,
     ACCOUNT,
+    ALIAS_MODAL,
     APPS_FORM,
     BOTTOM_SHEET,
     BROWSE_CHANNELS,

--- a/app/hooks/use_alias_setter.ts
+++ b/app/hooks/use_alias_setter.ts
@@ -1,0 +1,37 @@
+import {useCallback} from 'react';
+import {useIntl} from 'react-intl';
+import {executeCommand} from '@actions/remote/command';
+import {getUserIdFromChannelName} from '@utils/user';
+
+type UseAliasSetterProps = {
+    serverUrl: string;
+    channelId: string;
+    currentUserId: string;
+    searchTerm: string;
+};
+
+export const useAliasSetter = ({serverUrl, channelId, currentUserId, searchTerm}: UseAliasSetterProps) => {
+    const intl = useIntl();
+
+    const setAlias = useCallback(async (aliasText: string) => {
+        if (!aliasText.trim()) {
+            return {error: 'Alias cannot be empty'};
+        }
+
+        const teammateId = getUserIdFromChannelName(currentUserId, searchTerm);
+        if (!teammateId) {
+            return {error: 'Could not determine user ID'};
+        }
+
+        const command = `/alias set ${teammateId} ${aliasText.trim()}`;
+        
+        try {
+            const result = await executeCommand(serverUrl, intl, command, channelId);
+            return result;
+        } catch (error) {
+            return {error};
+        }
+    }, [serverUrl, intl, channelId, currentUserId, searchTerm]);
+
+    return {setAlias};
+}; 

--- a/app/screens/channel/header/alias_modal.tsx
+++ b/app/screens/channel/header/alias_modal.tsx
@@ -1,0 +1,164 @@
+import React, {useState, useCallback} from 'react';
+import {useIntl} from 'react-intl';
+import {View, Text, TouchableOpacity, Alert, Keyboard} from 'react-native';
+import {useTheme} from '@context/theme';
+import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
+import {typography} from '@utils/typography';
+import FloatingTextInput from '@components/floating_text_input_label';
+import {dismissModal} from '@screens/navigation';
+import {useAliasSetter} from '@hooks/use_alias_setter';
+
+const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => ({
+    container: {
+        flex: 1,
+        backgroundColor: theme.centerChannelBg,
+    },
+    content: {
+        padding: 20,
+        flex: 1,
+    },
+    title: {
+        ...typography('Heading', 600, 'SemiBold'),
+        color: theme.centerChannelColor,
+        marginBottom: 16,
+        textAlign: 'center',
+    },
+    input: {
+        marginBottom: 16,
+    },
+    buttons: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        marginTop: 'auto',
+    },
+    button: {
+        flex: 1,
+        padding: 12,
+        borderRadius: 4,
+        marginHorizontal: 4,
+        alignItems: 'center',
+    },
+    buttonCancel: {
+        backgroundColor: changeOpacity(theme.centerChannelColor, 0.1),
+    },
+    buttonConfirm: {
+        backgroundColor: theme.buttonBg,
+    },
+    buttonText: {
+        ...typography('Body', 200, 'SemiBold'),
+    },
+    buttonTextCancel: {
+        color: theme.centerChannelColor,
+    },
+    buttonTextConfirm: {
+        color: theme.buttonColor,
+    },
+}));
+
+type Props = {
+    initialAlias?: string;
+    serverUrl: string;
+    channelId: string;
+    currentUserId: string;
+    searchTerm: string;
+};
+
+const dismissModalAndKeyboard = () => {
+    Keyboard.dismiss();
+    setTimeout(() => {
+        dismissModal();
+    }, 100);
+};
+
+const AliasModal = ({initialAlias, serverUrl, channelId, currentUserId, searchTerm}: Props) => {
+    const {formatMessage} = useIntl();
+    const theme = useTheme();
+    const styles = getStyleSheet(theme);
+    const [alias, setAlias] = useState(initialAlias || '');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const {setAlias: executeSetAlias} = useAliasSetter({
+        serverUrl,
+        channelId,
+        currentUserId,
+        searchTerm,
+    });
+
+    const handleSubmit = useCallback(async () => {
+        if (!alias.trim()) {
+            Alert.alert(
+                formatMessage({id: 'channel_header.set_alias.error.title', defaultMessage: 'Error'}),
+                formatMessage({id: 'channel_header.set_alias.error.empty', defaultMessage: 'Alias cannot be empty'}),
+            );
+            return;
+        }
+
+        setIsSubmitting(true);
+        try {
+            const result = await executeSetAlias(alias);
+            if (result.error) {
+                Alert.alert(
+                    formatMessage({id: 'channel_header.set_alias.error.title', defaultMessage: 'Error'}),
+                    typeof result.error === 'string' ? result.error : formatMessage({id: 'channel_header.set_alias.error.unknown', defaultMessage: 'Failed to set alias'}),
+                );
+            } else {
+                dismissModalAndKeyboard();
+            }
+        } catch (error) {
+            Alert.alert(
+                formatMessage({id: 'channel_header.set_alias.error.title', defaultMessage: 'Error'}),
+                formatMessage({id: 'channel_header.set_alias.error.unknown', defaultMessage: 'Failed to set alias'}),
+            );
+        } finally {
+            setIsSubmitting(false);
+        }
+    }, [alias, executeSetAlias, formatMessage]);
+
+    const handleCancel = useCallback(() => {
+        dismissModalAndKeyboard();
+    }, []);
+
+    return (
+        <View style={styles.content}>
+                <Text style={styles.title}>
+                    {formatMessage({id: 'channel_header.set_alias.title', defaultMessage: 'Set Alias'})}
+                </Text>
+                <FloatingTextInput
+                    label={formatMessage({id: 'channel_header.set_alias.placeholder', defaultMessage: 'Enter alias for this user'})}
+                    value={alias}
+                    onChangeText={setAlias}
+                    theme={theme}
+                    style={styles.input}
+                    autoFocus={true}
+                    returnKeyType='done'
+                    onSubmitEditing={handleSubmit}
+                    editable={!isSubmitting}
+                />
+                <View style={styles.buttons}>
+                    <TouchableOpacity
+                        style={[styles.button, styles.buttonCancel]}
+                        onPress={handleCancel}
+                        disabled={isSubmitting}
+                    >
+                        <Text style={[styles.buttonText, styles.buttonTextCancel]}>
+                            {formatMessage({id: 'mobile.alert.cancel', defaultMessage: 'Cancel'})}
+                        </Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                        style={[styles.button, styles.buttonConfirm]}
+                        onPress={handleSubmit}
+                        disabled={isSubmitting}
+                    >
+                        <Text style={[styles.buttonText, styles.buttonTextConfirm]}>
+                            {isSubmitting 
+                                ? formatMessage({id: 'mobile.alert.submitting', defaultMessage: 'Setting...'})
+                                : formatMessage({id: 'mobile.alert.ok', defaultMessage: 'OK'})
+                            }
+                        </Text>
+                    </TouchableOpacity>
+                </View>
+            </View>
+    );
+};
+
+export default AliasModal; 

--- a/app/screens/channel/header/index.ts
+++ b/app/screens/channel/header/index.ts
@@ -111,6 +111,7 @@ const enhanced = withObservables(['channelId'], ({channelId, database}: OwnProps
         searchTerm,
         teamId,
         alias,
+        currentUserId,
     };
 });
 

--- a/app/screens/index.tsx
+++ b/app/screens/index.tsx
@@ -292,6 +292,9 @@ Navigation.setLazyComponentRegistrator((screenName) => {
         case Screens.CALL_HOST_CONTROLS:
             screen = withServerDatabase(require('@calls/screens/host_controls').default);
             break;
+        case Screens.ALIAS_MODAL:
+            screen = withServerDatabase(require('@screens/channel/header/alias_modal').default);
+            break;
     }
 
     if (screen) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
